### PR TITLE
streamline test

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,14 +1,12 @@
 setup() {
   set -eu -o pipefail
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export TESTDIR=~/tmp/test-php-dump
+  export PROJNAME=test-ddev-php-dumper
+  export TESTDIR=~/tmp/${PROJNAME}
   mkdir -p $TESTDIR
-  export PROJNAME=test-php-dump
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
-  ddev config --project-name=${PROJNAME}
-  ddev start -y >/dev/null
 }
 
 health_checks() {
@@ -26,17 +24,22 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
+
+  ddev config --project-name=${PROJNAME}
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${DIR}
   ddev restart
+
   health_checks
 }
 
 @test "install from release" {
   set -eu -o pipefail
-  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
+  cd ${TESTDIR}
+  ddev config --project-name=${PROJNAME}
   echo "# ddev get tyler36/ddev-php-dumper with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get tyler36/ddev-php-dumper
-  ddev restart >/dev/null
+  ddev restart
+
   health_checks
 }


### PR DESCRIPTION
This PR updates BATS tests by

- standardizing code common to both tests
- speeding up tests by removing "ddev start"
