### PR TITLE
Remove "extra_hosts"

### DIFF
--- a/docker-compose.php-dumper.yaml
+++ b/docker-compose.php-dumper.yaml
@@ -4,7 +4,3 @@ services:
         environment:
         - "VAR_DUMPER_FORMAT=server"
         - "VAR_DUMPER_SERVER=${VAR_DUMPER_SERVER:-localhost}:9912"
-        # The following is only require if using Docker Desktop PHP Dump extention.
-        # It does no harm elsewise so we'll leave it to make it easier to switch providers.
-        extra_hosts:
-        - "host.docker.internal:host-gateway"


### PR DESCRIPTION
This PR removes the "extra_hosts" section which was "required" by Desktop Docker.

This week (2024-09-17), tests against HEAD began failing with the following error:

```
 services.web.extra_hosts array items[0,1] must be unique'
````

After investigation, the addon appears to work without the line in WSL with Docker Desktop `4.32.2` and DDEV `1.23.4`


## Manual Test

1. Install project in WSL using Docker Desktop as docker provider.
1. Confirm project is accessible
1. Install addon following instructions for Docker Desktop.
1. Add `dump('hello')` to website and hit it.
1. Output should _not_ appear on page, instead appearing in PHP Dump in Docker Desktop.

