### PR TITLE
Add "release" tag to test

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -33,6 +33,7 @@ teardown() {
   health_checks
 }
 
+# bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR}


### PR DESCRIPTION
This PR adds the `test_tags=release` tag.
This allows conditional running of tests based on tag presence or absence.

This requires ddev-action-add-on `v2.1.0`.