### PR TITLE
fix: Addon refresh

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: 🐞 Bug report or Support Request
+description: Create a report to help us improve.
+labels: [bug]
+body:
+  - type: checkboxes
+    attributes:
+      label: Preliminary checklist
+      description: Please complete the following checks before submitting an issue.
+      options:
+        - label: I am using the latest stable version of DDEV
+          required: true
+        - label: I am using the latest stable version of this add-on
+          required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Actual Behavior
+      description: What actually happened instead?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Specific steps to reproduce the behavior.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run `...`
+        4. See error...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Screenshots? Anything that will give us more context about your issue!
+
+        💡 Attach images or log files by clicking this area to highlight it and dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: 🚀 Feature request
+description: Suggest an idea for this project.
+labels: [enhancement]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search existing issues to see if one already exists for your request.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem?
+      description: Clearly and concisely describe the problem. (Ex. I'm always frustrated when...)
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe your solution
+      description: Clearly and concisely describe what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe alternatives
+      description: Clearly and concisely describe any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## The Issue
+
+- #<issue number>
+
+<!-- Provide a brief description of the issue. -->
+
+## How This PR Solves The Issue
+
+## Manual Testing Instructions
+
+```bash
+ddev add-on get https://github.com/tyler36/ddev-php-dumper/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
+ddev restart
+```
+
+## Automated Testing Overview
+
+<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
+
+## Release/Deployment Notes
+
+<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![tests](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2026.svg)
+[![tests](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml)
 
 # ddev-php-dumper <!-- omit in toc -->
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![tests](https://github.com/tyler36/ddev-php-dumper/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-php-dumper/actions/workflows/tests.yml)
+[![last commit](https://img.shields.io/github/last-commit/tyler36/ddev-php-dumper)](https://github.com/tyler36/ddev-php-dumper/commits)
 
 # ddev-php-dumper <!-- omit in toc -->
 

--- a/README.md
+++ b/README.md
@@ -50,16 +50,8 @@ If you project is based on Symfony (such as Laravel, Drupal), it may already inc
 
 1. Install ddev-php-dump addon and restart to activate the addon.
 
-    For DDEV v1.23.5 or above run
-
     ```shell
     ddev add-on get tyler36/ddev-php-dumper
-    ```
-
-    For earlier versions of DDEV run
-
-    ```shell
-    ddev get tyler36/ddev-php-dumper
     ```
 
     Then restart your project

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![tests](https://github.com/tyler36/ddev-php-dumper/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-php-dumper/actions/workflows/tests.yml)
 [![last commit](https://img.shields.io/github/last-commit/tyler36/ddev-php-dumper)](https://github.com/tyler36/ddev-php-dumper/commits)
+[![release](https://img.shields.io/github/v/release/tyler36/ddev-php-dumper)](https://github.com/tyler36/ddev-php-dumper/releases/latest)
 
 # ddev-php-dumper <!-- omit in toc -->
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
 [![tests](https://github.com/tyler36/ddev-php-dumper/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-php-dumper/actions/workflows/tests.yml)
 [![last commit](https://img.shields.io/github/last-commit/tyler36/ddev-php-dumper)](https://github.com/tyler36/ddev-php-dumper/commits)
 [![release](https://img.shields.io/github/v/release/tyler36/ddev-php-dumper)](https://github.com/tyler36/ddev-php-dumper/releases/latest)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![tests](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml)
+[![tests](https://github.com/tyler36/ddev-php-dumper/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-php-dumper/actions/workflows/tests.yml)
 
 # ddev-php-dumper <!-- omit in toc -->
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 - [What does this add-on do?](#what-does-this-add-on-do)
 - [Requirements](#requirements)
 - [Installation](#installation)
-    - [Docker "PHP Dump" setup](#docker-php-dump-setup)
-        - [Troubleshooting](#troubleshooting)
-    - ["var-dump server" setup](#var-dump-server-setup)
+  - [Docker "PHP Dump" setup](#docker-php-dump-setup)
+    - [Troubleshooting](#troubleshooting)
+  - ["var-dump server" setup](#var-dump-server-setup)
 - [Usage](#usage)
-    - [Disable the service](#disable-the-service)
+  - [Disable the service](#disable-the-service)
 - [Reference](#reference)
 
 ## What is ddev-php-dumper?

--- a/install.yaml
+++ b/install.yaml
@@ -7,3 +7,9 @@ project_files:
 # DDEV environment variables can be interpolated into these actions
 post_install_actions:
 - chmod +x commands/web/dumper
+
+# Version constraint for DDEV that will be validated against the running DDEV executable
+# and prevent add-on from being installed if it doesn't validate.
+# See https://github.com/Masterminds/semver#checking-version-constraints for constraint rules.
+# Available with DDEV v1.23.4+, and works only for DDEV v1.23.4+ binaries
+ddev_version_constraint: '>= v1.24.3'


### PR DESCRIPTION
## Solution

This PR updates the addon to current practises.
It's mostly related to status badges.
However, it does restrict the addon to DDEV 1.24.3 or above.

## Test

1. Run the following script (draft)

```shell
curl -fsSL https://raw.githubusercontent.com/ddev/ddev-addon-template/20250430_stasadev_update_checker/.github/scripts/update-checker.sh | bash
```
